### PR TITLE
Heroku needs ruby version in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ git_source(:github) do |repo_name|
   "https://github.com/#{repo_name}.git"
 end
 
+ruby '2.3.3'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.0.1'


### PR DESCRIPTION
The Heroku deployment has been set up with clear DB.  All merges to master will not auto-deply to gbtisaas.herokuapp.com

Heroku requires that the version of ruby being used is specified in the gemfile.