### PR TITLE
Message sorting

### DIFF
--- a/app/controllers/guestbooks_controller.rb
+++ b/app/controllers/guestbooks_controller.rb
@@ -19,6 +19,8 @@ class GuestbooksController < ApplicationController
       @messages = Message.where('guestbook_id = ' + params[:id]).order('votes DESC')
     when 'alphabet'
       @messages = Message.where('guestbook_id = ' + params[:id]).order('content ASC')
+    when 'controversial'
+      @messages = Message.where('guestbook_id = ' + params[:id]).order('(votes_cast - votes) DESC')
     else
       @messages = Message.where('guestbook_id = ' + params[:id])
     end

--- a/app/controllers/guestbooks_controller.rb
+++ b/app/controllers/guestbooks_controller.rb
@@ -10,6 +10,18 @@ class GuestbooksController < ApplicationController
   # GET /guestbooks/1
   # GET /guestbooks/1.json
   def show
+    #abort @guestbook.messages.inspect
+    #@messages = Message.where('guestbook_id = ' + params[:id])
+    case sort_params[:sort_by]
+    when 'recent'
+      @messages = Message.where('guestbook_id = ' + params[:id]).order('created_at DESC')
+    when 'votes'
+      @messages = Message.where('guestbook_id = ' + params[:id]).order('votes DESC')
+    when 'alphabet'
+      @messages = Message.where('guestbook_id = ' + params[:id]).order('content ASC')
+    else
+      @messages = Message.where('guestbook_id = ' + params[:id])
+    end
   end
 
   # GET /guestbooks/new
@@ -79,5 +91,9 @@ class GuestbooksController < ApplicationController
     # Never trust parameters from the scary internet, only allow the white list through.
     def guestbook_params
       params.require(:guestbook).permit(:title, :archived)
+    end
+
+    def sort_params
+      params.permit(:sort_by)
     end
 end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -13,6 +13,7 @@ class Message < ApplicationRecord
 
   def cast_vote up
     self.votes += up ? 1 : -1
+    self.votes_cast += 1
     self.save
   end
 

--- a/app/views/guestbooks/show.html.erb
+++ b/app/views/guestbooks/show.html.erb
@@ -13,7 +13,7 @@
 <p>
   <strong>Messages:</strong>
   <ul>
-    <% @guestbook.messages.each do |msg| %>
+    <% @messages.each do |msg| %>
       <% if msg.approved %>
         <li><%= msg.content %></li>
       <% end %>

--- a/db/migrate/20170303143116_add_votes_cast_to_messages.rb
+++ b/db/migrate/20170303143116_add_votes_cast_to_messages.rb
@@ -1,0 +1,6 @@
+class AddVotesCastToMessages < ActiveRecord::Migration[5.0]
+  def change
+    add_column :messages, :votes_cast, :int, :default => 0
+    Message.update_all('votes_cast = votes')
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170209185430) do
+ActiveRecord::Schema.define(version: 20170303143116) do
 
   create_table "guestbooks", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string   "title"
@@ -24,10 +24,11 @@ ActiveRecord::Schema.define(version: 20170209185430) do
   create_table "messages", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.text     "content",      limit: 65535
     t.boolean  "approved"
-    t.datetime "created_at",                 null: false
-    t.datetime "updated_at",                 null: false
+    t.datetime "created_at",                             null: false
+    t.datetime "updated_at",                             null: false
     t.integer  "guestbook_id"
     t.integer  "votes"
+    t.integer  "votes_cast",                 default: 0
     t.index ["guestbook_id"], name: "index_messages_on_guestbook_id", using: :btree
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,11 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+
+book = Guestbook.create!(title: 'My Gala', archived: false, created_at: 3.day.ago, is_default: true, 
+  description: "My test gala with sortable messages!");
+book.messages.create([
+  {content: 'Adam', approved: true, votes: 13},
+  {content: 'Max', approved: true, created_at: 1.day.ago, votes: 24},
+  {content: 'Richard', approved: true, created_at: 3.day.ago, votes: 17}
+]);

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -11,5 +11,6 @@ book = Guestbook.create!(title: 'My Gala', archived: false, created_at: 3.day.ag
 book.messages.create([
   {content: 'Adam', approved: true, votes: 13},
   {content: 'Max', approved: true, created_at: 1.day.ago, votes: 24},
-  {content: 'Richard', approved: true, created_at: 3.day.ago, votes: 17}
+  {content: 'Richard', approved: true, created_at: 3.day.ago, votes: 17},
+  {content: 'James', approved: true, created_at: 3.day.ago, votes: 17, votes_cast: 34}
 ]);


### PR DESCRIPTION
Can now choose how messages are sorted within the guestbook view by passing a sort_by param in the GET request.  Valid sort options are : recent, votes, alphabet, and controversial.  

One side effect of this is you can no longer user @guestbook.messages to grab the messages in the view.  Use @messages instead since the controller will populate this with the sorted list.  