### PR TITLE
Guestbook cleanup

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
 web: bundle exec rails server -p $PORT
+release: rails db:migrate RAILS_ENV=production

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -25,7 +25,11 @@ class MessagesController < ApplicationController
   # POST /messages
   # POST /messages.json
   def create
-    @message = Message.new(message_params)
+    _params = message_params
+    if _params[:guestbook_id] == nil
+      _params[:guestbook_id] = Guestbook.get_default.id
+    end
+    @message = Message.new(_params)
 
     respond_to do |format|
       if @message.save

--- a/db/migrate/20170304014944_change_message_default_values.rb
+++ b/db/migrate/20170304014944_change_message_default_values.rb
@@ -1,0 +1,6 @@
+class ChangeMessageDefaultValues < ActiveRecord::Migration[5.0]
+  def change
+    change_column_default :messages, :approved, true
+    change_column_default :messages, :votes, 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170303143116) do
+ActiveRecord::Schema.define(version: 20170304014944) do
 
   create_table "guestbooks", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string   "title"
@@ -23,25 +23,13 @@ ActiveRecord::Schema.define(version: 20170303143116) do
 
   create_table "messages", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.text     "content",      limit: 65535
-    t.boolean  "approved"
-    t.datetime "created_at",                             null: false
-    t.datetime "updated_at",                             null: false
+    t.boolean  "approved",                   default: true
+    t.datetime "created_at",                                null: false
+    t.datetime "updated_at",                                null: false
     t.integer  "guestbook_id"
-    t.integer  "votes"
+    t.integer  "votes",                      default: 0
     t.integer  "votes_cast",                 default: 0
     t.index ["guestbook_id"], name: "index_messages_on_guestbook_id", using: :btree
-  end
-
-  create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.datetime "created_at",                     null: false
-    t.datetime "updated_at",                     null: false
-    t.string   "email",                          null: false
-    t.string   "encrypted_password", limit: 128, null: false
-    t.string   "confirmation_token", limit: 128
-    t.string   "remember_token",     limit: 128, null: false
-    t.boolean  "active"
-    t.index ["email"], name: "index_users_on_email", using: :btree
-    t.index ["remember_token"], name: "index_users_on_remember_token", using: :btree
   end
 
 end


### PR DESCRIPTION
I've added default values for votes and approved to messages so that you can now create a message through a json request with just a content field, and it will be auto approved and added to the default guestbook (should work well for poster fair, I can change it to auto approved = false later if we want)

Also I changed the Heroku procfile cause I had to migrate the db myself earlier today, it should happen automatically now.